### PR TITLE
Rename plugin in WP admin dashboard

### DIFF
--- a/security_headers.php
+++ b/security_headers.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Plugin Name: HTTP Headers
+ * Plugin Name: Security Headers
  * Plugin URI: http://surevine.com/
  * Description: Sets security related headers (HSTS etc)
  * Version: 0.8


### PR DESCRIPTION
Stops this madness http://prnt.sc/c70gdk and aligns with WP plugin name
